### PR TITLE
Fixed display field with a long issue summary and issue which is not in JQL query

### DIFF
--- a/queryfields/src/main/java/ru/mail/jira/plugins/lf/LinkerField.java
+++ b/queryfields/src/main/java/ru/mail/jira/plugins/lf/LinkerField.java
@@ -273,14 +273,8 @@ public class LinkerField
 
                 String selected = Consts.EMPTY_VALUE;
                 String value = (String) issue.getCustomFieldValue(field);
-                for (Map.Entry<String, String> cf : cfVals.entrySet())
-                {
-                    if (value != null && cf.getKey().equals(value))
-                    {
-                        selected = value;
-                        break;
-                    }
-                }
+                if (value != null)
+                    selected = value;
 
                 if (isAutocompleteView)
                 {

--- a/queryfields/src/main/resources/templates/edit-linkerfield.vm
+++ b/queryfields/src/main/resources/templates/edit-linkerfield.vm
@@ -21,7 +21,7 @@
     <input value='$i18n.getText("queryfields.field.error")' class='textfield' readonly='readonly'/>
     #else
     <input type="hidden" name="$customField.id" value="$selected" id="$customField.id" class="textfield" readonly="readonly"/>
-    <select id="linker$customField.id" name="linker$customField.id" onchange="setQueryFieldValue('linker$customField.id', '$customField.id');">
+    <select class="select long-field" id="linker$customField.id" name="linker$customField.id" onchange="setQueryFieldValue('linker$customField.id', '$customField.id');">
     #foreach($val in $cfVals.entrySet())
         <option value="$val.key" #if($val.key == $selected)selected="selected"#end>${val.value}</option>
     #end


### PR DESCRIPTION
1. Поле выходило за приделы формы создания запроса, если в автокомплите были таски с очень длинным названием.
2. Если настройка у поля с автокомплитом, но без пустого значения, то при внесении существующей задачи не из списка JQL ничего не отображалось и давало создать задачу.
   Сделала так, что если даже выбранный таск не из списка автокомплита, то его отображаем в поле.
